### PR TITLE
Fixed issue with parallelization

### DIFF
--- a/z-mapper.sh
+++ b/z-mapper.sh
@@ -16,6 +16,8 @@ map_images () {
 		elif (( ${_MAPLOCK} >= 6 )); then
 			wait
 			_MAPLOCK=0
+			map_z_releases &
+                        ((_MAPLOCK++))
 		fi
 	done
 	# Wait for any remaining thread
@@ -142,6 +144,8 @@ do
 	elif (( ${_IMAGELOCK} >= 3 )); then
 		wait
 		_IMAGELOCK=0
+		map_images &
+                ((_IMAGELOCK++))
 	fi
 done
 


### PR DESCRIPTION
First of all this script is awesome and has been very useful so thank you for sharing it! 

I noticed that when I changed the `_IMAGES` variable to include a much larger list of images that some some images would not be processed at all.

When the counter variables exceed the limit that is defined in the `elif` statements ( within the `for` loops ) there is a `wait` and a reset of the counter variables but no further action for that iteration of the `for` loop. Whenever an image in the list goes through an iteration of that `for` loop and hits that `elif` statement it wont do any skopeo inspects or processing for that image and instead skips ahead to the next one. 

I've added new lines inside the `elif` statements so that the images in that iteration of the `for` loop are not skipped after the `wait` completes and counter is reset. 

I did some debugging and testing of this with a list of approx 90 images hosted on a local docker registry.

Let me know if you have any questions and thanks again for the script.

Woody,